### PR TITLE
Don't mutate default headers object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -321,7 +321,7 @@ export class TokenApiService {
       method = 'GET';
     }
 
-    headers = Object.assign(this.defaultHeaders, headers);
+    headers = Object.assign({}, this.defaultHeaders, headers);
 
     if (token && authenticate) {
       (


### PR DESCRIPTION
# Summary

Fixes a bug where we were mutating the default headers object, which meant unwanted headers were being kept around for subsequent requests.