### PR TITLE
Return action and meta when request finishes or fails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,20 +194,21 @@ export class TokenApiService {
   }
 
   completeApiRequest(type, finalResponse) {
-    this.dispatch(createCompletionAction(
+    const action = createCompletionAction(
       type, finalResponse, this.meta,
-    ));
-    return finalResponse;
+    )
+    this.dispatch(action);
+    return action;
   }
 
-  defaultCatchApiRequestError(type, error) {
-    return error;
+  defaultCatchApiRequestError(type, error, meta) {
+    return { error, meta };
   }
 
   catchApiRequestError(type, error) {
     const fn = this.configOrDefault('catchApiRequestError');
     this.dispatch(createFailureAction(type, error, this.meta));
-    return fn(type, error);
+    return fn(type, error, this.meta);
   }
 
   preserveHeaderValues(meta, response) {


### PR DESCRIPTION
# Summary

When a request completes, it is useful to have access to some additional information. This PR returns the API actions metadata once a request finishes successfully or fails.
